### PR TITLE
Fix: replace api for GuessThePokemon command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ```bash
 npm i falgames@latest
 ```
+Please note that Node v18+ is required.
 
 ## **✨ Features**
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "html-entities": "^2.3.3",
     "node-fetch": "^2.6.7"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "homepage": "https://github.com/falcao-g/Falgames#readme",
   "keywords": [
     "discord",

--- a/src/GuessThePokemon.js
+++ b/src/GuessThePokemon.js
@@ -1,7 +1,7 @@
 const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
 const fetch = require('node-fetch');
 const events = require('events');
-const canvas = require('canvas');
+const { createCanvas, loadImage } = require('canvas');
 
 
 module.exports = class GuessThePokemon extends events {
@@ -109,11 +109,11 @@ module.exports = class GuessThePokemon extends events {
   async createQuestionImage(pokemonImgURL) {
     const size = 475;
     // Create a canvas and draw the pokemon image on it
-    const cv = canvas.createCanvas(size, size);
-    const ctx = cv.getContext('2d');
-    const img = await canvas.loadImage(pokemonImgURL);
-    ctx.drawImage(img, 0, 0, cv.width, cv.height);
-    const imageData = ctx.getImageData(0, 0, cv.width, cv.height);
+    const canvas = createCanvas(size, size);
+    const ctx = canvas.getContext('2d');
+    const img = await loadImage(pokemonImgURL);
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
     const data = imageData.data;
   
     const pxColor = [0, 0, 0]; // Black color
@@ -126,6 +126,6 @@ module.exports = class GuessThePokemon extends events {
     }
   
     ctx.putImageData(imageData, 0, 0);
-    return cv.toBuffer();
+    return canvas.toBuffer();
   }
 }

--- a/src/GuessThePokemon.js
+++ b/src/GuessThePokemon.js
@@ -1,6 +1,7 @@
 const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
 const fetch = require('node-fetch');
 const events = require('events');
+const canvas = require('canvas');
 
 
 module.exports = class GuessThePokemon extends events {
@@ -47,10 +48,15 @@ module.exports = class GuessThePokemon extends events {
       this.options.isSlashGame = true;
     }
 
-    const result = await fetch('https://api.aniket091.xyz/pokemon').then(res => res.json()).catch(e => { return {} });
-    if (!result.data) return this.sendMessage({ content: this.options.errMessage });
-    this.pokemon = result.data;
+    const API_URL = 'https://pokeapi.co/api/v2/pokemon/';
+    const result = await fetch( API_URL + this.randomInt(1, 1025)).then(res => res.json()).catch(e => { return null });
+    if (!result) return this.sendMessage({ content: this.options.errMessage });
 
+    this.pokemon.name = result.species.name;
+    this.pokemon.types = result.types.map(t => t.type.name);
+    this.pokemon.abilities = result.abilities.map(a => a.ability.name);
+    this.pokemon.answerImage = result.sprites.other['official-artwork'].front_default;
+    this.pokemon.questionImage = await this.createQuestionImage(result.sprites.other['official-artwork'].front_default);
 
     const embed = new EmbedBuilder()
     .setColor(this.options.embed.color)
@@ -78,7 +84,6 @@ module.exports = class GuessThePokemon extends events {
     })
   }
 
-
   async gameOver(msg, result) {
     const GuessThePokemonGame = { player: this.message.author, pokemon: this.pokemon };
     this.emit('gameOver', { result: result ? 'win' : 'lose', ...GuessThePokemonGame });
@@ -95,5 +100,32 @@ module.exports = class GuessThePokemon extends events {
 
     const attachment = new AttachmentBuilder(this.pokemon.answerImage, { name: 'answer-image.png' });
     return msg.edit({ content: this.options.winMessage.replace('{pokemon}', this.pokemon.name), embeds: [embed], files: [attachment] });
+  }
+
+  randomInt(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+  
+  async createQuestionImage(pokemonImgURL) {
+    const size = 475;
+    // Create a canvas and draw the pokemon image on it
+    const cv = canvas.createCanvas(size, size);
+    const ctx = cv.getContext('2d');
+    const img = await canvas.loadImage(pokemonImgURL);
+    ctx.drawImage(img, 0, 0, cv.width, cv.height);
+    const imageData = ctx.getImageData(0, 0, cv.width, cv.height);
+    const data = imageData.data;
+  
+    const pxColor = [0, 0, 0]; // Black color
+    // Loop through the image data and change the color of the non-transparent pixels to black
+    for (let i = 0; i < data.length; i += 4) {
+      if (data[i + 3] < 10) continue; // skip transparent pixels (alpha < 10)
+      data[i] = pxColor[0];
+      data[i + 1] = pxColor[1];
+      data[i + 2] = pxColor[2];
+    }
+  
+    ctx.putImageData(imageData, 0, 0);
+    return cv.toBuffer();
   }
 }

--- a/src/GuessThePokemon.js
+++ b/src/GuessThePokemon.js
@@ -1,5 +1,4 @@
 const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
-const fetch = require('node-fetch');
 const events = require('events');
 const { createCanvas, loadImage } = require('canvas');
 
@@ -87,8 +86,8 @@ module.exports = class GuessThePokemon extends events {
   async gameOver(msg, result) {
     const GuessThePokemonGame = { player: this.message.author, pokemon: this.pokemon };
     this.emit('gameOver', { result: result ? 'win' : 'lose', ...GuessThePokemonGame });
-    if (!result) return msg.edit({ content: this.options.loseMessage.replace('{pokemon}', this.pokemon.name), embeds: [], attachments: [] });
 
+    const resultMessage = result ? this.options.winMessage : this.options.loseMessage;
 
     const embed = new EmbedBuilder()
     .setColor(this.options.embed.color)
@@ -99,7 +98,7 @@ module.exports = class GuessThePokemon extends events {
     .setAuthor({ name: this.message.author.tag, iconURL: this.message.author.displayAvatarURL({ dynamic: true }) });
 
     const attachment = new AttachmentBuilder(this.pokemon.answerImage, { name: 'answer-image.png' });
-    return msg.edit({ content: this.options.winMessage.replace('{pokemon}', this.pokemon.name), embeds: [embed], files: [attachment] });
+    return msg.edit({ content: resultMessage.replace('{pokemon}', this.pokemon.name), embeds: [embed], files: [attachment] });
   }
 
   randomInt(min, max) {


### PR DESCRIPTION
## What does this PR do?
Now we utilize the PokéApi, a famous and solid api for getting pokemon data. First we get the answer image, then we manipulate it to turn all black and send to the user guess it.

## Summary of changes
<!-- List what changed in the project Example: Changed function X, added command Y -->

## Media
https://github.com/falcao-g/Falgames/assets/56037523/c21897f0-1253-4485-bd00-ef3bc6bb9975


## Status
<!-- Check the boxes that apply to this PR using "x" -->
- [x] These changes have been tested and formatted properly.
- [ ] These changes also include the change in documentation accordingly.
- [ ] This PR introduces some Breaking changes.
