### PR TITLE
fix: match pairs never timeout (#8)

### DIFF
--- a/src/MatchPairs.js
+++ b/src/MatchPairs.js
@@ -122,7 +122,7 @@ module.exports = class MatchPairs extends events {
 
 
   async handleButtons(msg) {
-    const collector = msg.createMessageComponentCollector({ idle: this.options.time });
+    const collector = msg.createMessageComponentCollector({ idle: this.options.timeoutTime });
 
     collector.on('collect', async btn => {
       await btn.deferUpdate().catch(e => {});


### PR DESCRIPTION
<!-- Insert here the linking word and issue number, if applicable -->
closes #8 

## What does this PR do?
<!-- Please write a description about what has changed with this PR, also include any motivation or context necessary -->
Apply suggestion from issue #8,  by @zoli456.

<!-- If necessary, also include screenshots and videos to show the changes  -->

## Summary of changes
<!-- List what changed in the project Example: Changed function X, added command Y -->
At MatchPairs.js:
```js
const collector = msg.createMessageComponentCollector({ idle: this.options.timeoutTime});
```` 

## Checklist
<!-- Check the boxes that apply to this PR using "x" -->
- [x] These changes have been tested and formatted properly.
- [ ] These changes also include the change in documentation accordingly.
- [ ] This PR introduces some breaking changes.
