### PR TITLE
fix: pokemon, trivia and rps

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "tasks": {
-    "dev": "deno run --watch test/index.js"
+    "dev": "deno run --watch  --allow-env --allow-ffi --allow-net test/index.js"
   },
   "dependencies": {
     "canvas": "^3.0.1",

--- a/examples/RockPaperScissors.md
+++ b/examples/RockPaperScissors.md
@@ -18,8 +18,8 @@ const Game = new RockPaperScissors({
 		scissors: "Scissors",
 	},
 	emojis: {
-		rock: "🌑",
-		paper: "📰",
+		rock: "🪨",
+		paper: "📄",
 		scissors: "✂️",
 	},
 	timeoutTime: 60000,
@@ -29,6 +29,8 @@ const Game = new RockPaperScissors({
 	tieMessage: "The Game tied! No one won the Game!",
 	timeoutMessage: "The Game went unfinished! No one won the Game!",
 	playerOnlyMessage: "Only {player} and {opponent} can use these buttons.",
+	requestMessage: "{opponent}, {player} has invited you for a round of **Rock Paper Scissors**.",
+	rejectMessage: "The player denied your request for a round of **Rock Paper Scissors**.",
 })
 
 Game.startGame()

--- a/examples/Trivia.md
+++ b/examples/Trivia.md
@@ -1,30 +1,32 @@
 # **❔ Trivia**
 
 ```js
-const { Trivia } = require('falgames');
+const { Trivia } = require("falgames")
 
 const Game = new Trivia({
-  message: message,
-  isSlashGame: false,
-  embed: {
-    title: 'Trivia',
-    color: '#551476',
-    description: 'You have 60 seconds to guess the answer.'
-  },
-  timeoutTime: 60000,
-  buttonStyle: 'PRIMARY',
-  trueButtonStyle: 'SUCCESS',
-  falseButtonStyle: 'DANGER',
-  mode: 'multiple',  // multiple || single
-  difficulty: 'medium',  // easy || medium || hard
-  winMessage: 'You won! The correct answer is {answer}.',
-  loseMessage: 'You lost! The correct answer is {answer}.',
-  errMessage: 'Unable to fetch question data! Please try again.',
-  playerOnlyMessage: 'Only {player} can use these buttons.'
-});
+	message: message,
+	isSlashGame: false,
+	embed: {
+		title: "Trivia",
+		color: "#551476",
+		description: "Your time to answer is going to end {timeoutTime}.",
+	},
+	timeoutTime: 60000,
+	buttonStyle: "PRIMARY",
+	trueButtonStyle: "SUCCESS",
+	falseButtonStyle: "DANGER",
+	mode: "multiple", // multiple || single
+	difficulty: "medium", // easy || medium || hard
+	winMessage: "You won! The correct answer is {answer}.",
+	loseMessage: "You lost! The correct answer is {answer}.",
+	errMessage: "Unable to fetch question data! Please try again.",
+	playerOnlyMessage: "Only {player} can use these buttons.",
+	categoryText: "Category",
+	difficultyText: "Difficulty",
+})
 
-Game.startGame();
-Game.on('gameOver', result => {
-  console.log(result);  // =>  { result... }
-});
+Game.startGame()
+Game.on("gameOver", (result) => {
+	console.log(result) // =>  { result... }
+})
 ```

--- a/src/RockPaperScissors.js
+++ b/src/RockPaperScissors.js
@@ -31,7 +31,7 @@ export class RockPaperScissors extends approve {
 	 * @param {string} [options.buttons.scissors='Scissors'] - The label for the scissors button.
 	 * @param {Object} [options.emojis] - The emojis for the game.
 	 * @param {string} [options.emojis.rock='🪨'] - The emoji for the rock button.
-	 * @param {string} [options.emojis.paper='📰'] - The emoji for the paper button.
+	 * @param {string} [options.emojis.paper='📄'] - The emoji for the paper button.
 	 * @param {string} [options.emojis.scissors='✂️'] - The emoji for the scissors button.
 	 * @param {number} [options.timeoutTime=60000] - The timeout time for the game.
 	 * @param {string} [options.buttonStyle='PRIMARY'] - The style for the buttons.
@@ -39,7 +39,7 @@ export class RockPaperScissors extends approve {
 	 * @param {string} [options.winMessage='**{player}** won the Game! Congratulations!'] - The win message for the game.
 	 * @param {string} [options.tieMessage='The Game tied! No one won the Game!'] - The tie message for the game.
 	 * @param {string} [options.timeoutMessage='The Game went unfinished! No one won the Game!'] - The timeout message for the game.
-	 * @param {string} [options.requestMessage='{player} has invited you for a round of **Rock Paper Scissors**.'] - The message to show when a player invites another player for a game.
+	 * @param {string} [options.requestMessage='{opponent}, {player} has invited you for a round of **Rock Paper Scissors**.'] - The message to show when a player invites another player for a game.
 	 * @param {string} [options.rejectMessage='The player denied your request for a round of **Rock Paper Scissors**.'] - The message to show when a player denies an invite for a game.
 	 * @param {string} [options.playerOnlyMessage] - The message to show when someone else tries to use the buttons.
 	 */
@@ -65,7 +65,7 @@ export class RockPaperScissors extends approve {
 
 		if (!options.emojis) options.emojis = {}
 		if (!options.emojis.rock) options.emojis.rock = "🪨"
-		if (!options.emojis.paper) options.emojis.paper = "📰"
+		if (!options.emojis.paper) options.emojis.paper = "📄"
 		if (!options.emojis.scissors) options.emojis.scissors = "✂️"
 
 		if (!options.timeoutTime) options.timeoutTime = 60000
@@ -75,7 +75,7 @@ export class RockPaperScissors extends approve {
 		if (!options.tieMessage) options.tieMessage = "The Game tied! No one won the Game!"
 		if (!options.timeoutMessage) options.timeoutMessage = "The Game went unfinished! No one won the Game!"
 		if (!options.requestMessage)
-			options.requestMessage = "{player} has invited you for a round of **Rock Paper Scissors**."
+			options.requestMessage = "{opponent}, {player} has invited you for a round of **Rock Paper Scissors**."
 		if (!options.rejectMessage)
 			options.rejectMessage = "The player denied your request for a round of **Rock Paper Scissors**."
 
@@ -106,6 +106,10 @@ export class RockPaperScissors extends approve {
 			throw new TypeError("INVALID_MESSAGE: Tie message option must be a string.")
 		if (typeof options.timeoutMessage !== "string")
 			throw new TypeError("INVALID_MESSAGE: Timeout message option must be a string.")
+		if (typeof options.requestMessage !== "string")
+			throw new TypeError("INVALID_MESSAGE: Request message option must be a string.")
+		if (typeof options.rejectMessage !== "string")
+			throw new TypeError("INVALID_MESSAGE: Reject message option must be a string.")
 		if (options.playerOnlyMessage !== false) {
 			if (!options.playerOnlyMessage) options.playerOnlyMessage = "Only {player} and {opponent} can use these buttons."
 			if (typeof options.playerOnlyMessage !== "string")

--- a/src/RockPaperScissors.js
+++ b/src/RockPaperScissors.js
@@ -30,7 +30,7 @@ export class RockPaperScissors extends approve {
 	 * @param {string} [options.buttons.paper='Paper'] - The label for the paper button.
 	 * @param {string} [options.buttons.scissors='Scissors'] - The label for the scissors button.
 	 * @param {Object} [options.emojis] - The emojis for the game.
-	 * @param {string} [options.emojis.rock='🌑'] - The emoji for the rock button.
+	 * @param {string} [options.emojis.rock='🪨'] - The emoji for the rock button.
 	 * @param {string} [options.emojis.paper='📰'] - The emoji for the paper button.
 	 * @param {string} [options.emojis.scissors='✂️'] - The emoji for the scissors button.
 	 * @param {number} [options.timeoutTime=60000] - The timeout time for the game.
@@ -64,7 +64,7 @@ export class RockPaperScissors extends approve {
 		if (!options.buttons.scissors) options.buttons.scissors = "Scissors"
 
 		if (!options.emojis) options.emojis = {}
-		if (!options.emojis.rock) options.emojis.rock = "🌑"
+		if (!options.emojis.rock) options.emojis.rock = "🪨"
 		if (!options.emojis.paper) options.emojis.paper = "📰"
 		if (!options.emojis.scissors) options.emojis.scissors = "✂️"
 


### PR DESCRIPTION
- **fix: pokemon name in title and answer image**
- **feat: add relative time and two options to trivia**
- **feat: improve rock emoji**
- **refactor: new paper emoji and request message**
- **chore: add flags in deno task dev**

## What does this PR do?
Fixes some documentation and code in guess the pokemon, trivia and RPS

## Summary of changes
- Adds pokemon name in title when over
- Fixes answer image in guess the pokemon
- Improve emojis in RPS
- Fixes documentation for all three commands
- Adds flags in deno task dev
- Improves trivia embed, adds answer in end
- Puts relative time in Trivia so user knows how much time has left

## Checklist
- [x] These changes have been tested and formatted properly.
- [x] These changes also include the change in documentation accordingly.
- [ ] This PR introduces some breaking changes.
